### PR TITLE
feat: cross-account access in client accounts 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,24 @@ resource "aws_iam_role" "this" {
   assume_role_policy = data.aws_iam_policy_document.hcp_oidc_assume_role_policy.json
 }
 
+# Allow the tfc-oidc-role to assume the Route53 delegation role in platform account
+resource "aws_iam_role_policy" "allow_crossaccount_route53" {
+  provider = aws.member_account
+  name     = "AllowRoute53DelegationAccess"
+  role     = aws_iam_role.this.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["sts:AssumeRole"],
+        Resource = "arn:aws:iam::${var.platform_utility_account_id}:role/Route53DelegationWrite"
+      }
+    ]
+  })
+}
+
 # Attach the AdministratorAccess policy to the IAM role in the member_account
 resource "aws_iam_role_policy_attachment" "admin_access" {
   provider  = aws.member_account

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,6 @@
 # Copyright (c) GEDI, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# Copyright (c) GEDI, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 variable "region" {
   description = "The AWS region where resources will be created."
   type        = string
@@ -20,8 +17,13 @@ variable "tfc_project_name" {
   type        = string
 }
 
+variable "platform_utility_account_id" {
+  description = "The account ID of the platform/root AWS account (e.g. where Route53 parent zone lives)"
+  type        = string
+}
+
 variable "token" {
-  description = "HCP Terraform admin user token for API authentication."
+  description = "HCP Terraform organization token for API authentication."
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
need for zone delegation in L2 application control plane layer when creating hosted zones for l3 apps